### PR TITLE
Planet Station STAGE.5の情報を更新

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yorudokimayu-info",
-  "version": "1.2.7",
+  "version": "1.2.8",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/src/services/biography/InMemoryBiographyService.ts
+++ b/src/services/biography/InMemoryBiographyService.ts
@@ -472,6 +472,22 @@ const eventHistoryMasterData: EventHistoryMaster[] = [
             })
         ],
     }),
+    new EventHistoryMaster({
+        date: new Date("2022-11-26"),
+        name: TranslatableValues.create([
+            ["ja", "柚子花主催LIVE -Planet Station- STAGE.5"],
+            ["en", "Planet Station STAGE.5 Virtual Artist Music Live Hosted by YUZUHA"],
+        ]),
+        links: [
+            new EventLinkMaster({
+                name: TranslatableValues.create([
+                    ["ja", "Z-aN"],
+                    ["en", "Z-aN"],
+                ]), 
+                url: "https://www.zan-live.com/live/detail/10251"
+            }),
+        ]
+    }),
 ];
 
 export const japaneseProfile: Profile = {

--- a/src/services/home/InMemoryNewsService.ts
+++ b/src/services/home/InMemoryNewsService.ts
@@ -37,14 +37,14 @@ export class NewsMaster {
 const newsMasterData: NewsMaster[] = [
     new NewsMaster({
         text: TranslatableValues.create([
-            ["ja", "柚子花主催LIVE -Planet Station- STAGE.5 (2022-11-26) 出演予定"],
-            ["en", "LIVE sponsored by Yuzuha -Planet Station- STAGE.5 (2022-11-26) "],
+            ["ja", "柚子花主催LIVE -Planet Station- STAGE.5 (2022-11-26) 出演"],
+            ["en", "Planet Station STAGE.5 Virtual Artist Music Live Hosted by YUZUHA (2022-11-26) "],
         ]),
         links: [
             new NewsLinkMaster({
                 name: TranslatableValues.create([
-                    ["ja", "Z-aN"],
-                    ["en", "Z-aN"],
+                    ["ja", "Z-aN (アーカイブ視聴 2022年12月3日 21:00迄)"],
+                    ["en", "Z-aN (The archive of the live will be available until Dec.3)"],
                 ]), 
                 url: "https://www.zan-live.com/live/detail/10251"
             }),


### PR DESCRIPTION
Close #119 

実施内容

* HomeのNewsについては、アーカイブ視聴の情報を追記した
    * HomeのNewsからの下げはアーカイブの視聴期間が終わってから
    * ついでにPlanet Station STAGE.5のページからイベント名の英語表記がわかったので修正
        * https://www.zan-live.com/live/detail/10262
        * 英語の語順に違和感あったので入れ替えている
* BiographyにPlanet Station STAGE.5を追加