### PR TITLE
2022年のエンタス忘年会をイベント出演歴へ移動 Newsは0件の場合はトルツメ

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -31,6 +31,11 @@ apiディレクトリを削除してsrcディレクトリにpagesとstylesを移
 * VisualStudioCodeのTERMINALから `docker-compose up` でNext.jsの開発サーバを起動
 * ブラウザから [http://localhost:3000](http://localhost:3000) にアクセス
 
+コンポーネントの見た目だけ確認したい場合
+
+* `docker-compose run --service-ports local storybook`
+* ブラウザから [http://localhost:6006](http://localhost:6006) にアクセス
+
 
 # ディレクトリ構成
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yorudokimayu-info",
-  "version": "1.2.9",
+  "version": "1.2.10",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/src/components/home/Index.tsx
+++ b/src/components/home/Index.tsx
@@ -1,10 +1,10 @@
 import React from "react";
-import NewsCard from "./NewsCard";
 import LinkCard from './LinkCard';
 import PageTitle from '../../components/common/PageTitle';
 import SectionTitle from '../../components/common/SectionTitle';
 import { ContentLink } from "../../services/home/ContentLinkService";
 import { NewsItem } from "../../services/home/NewsService";
+import News from "./News";
 
 export type Props = {
     siteName: string;
@@ -21,10 +21,7 @@ const Index: React.FC<Props> = ({siteName, siteDescription, news, links}) => {
             <p className="p8">
                 {siteDescription}
             </p>
-            <SectionTitle text="News" />
-            <div className="grid gap-y-1 divide-y">
-                {news.map((newItem, index) => <NewsCard newsItem={newItem} key={index} />)}
-            </div>
+            <News news={news} />
             <SectionTitle text="Table of contents" />
             <div className="grid grid-cols-1 md:grid-cols-2">
                 {links.map((contentLink, index) => <LinkCard contentLink={contentLink} key={index} />)}

--- a/src/components/home/News.tsx
+++ b/src/components/home/News.tsx
@@ -1,0 +1,21 @@
+import NewsCard from "./NewsCard";
+import SectionTitle from '../../components/common/SectionTitle';
+import { NewsItem } from "../../services/home/NewsService";
+
+export type Props = {
+    news: NewsItem[];
+};
+const News: React.FC<Props>  = ({news}) => {
+    if (news.length == 0) {
+        return null;
+    }
+
+    return <>
+        <SectionTitle text="News" />
+        <div className="grid gap-y-1 divide-y" data-test-id="news">
+            {news.map((newItem, index) => <NewsCard newsItem={newItem} key={index} />)}
+        </div>
+    </>
+}
+
+export default News;

--- a/src/services/biography/InMemoryBiographyService.ts
+++ b/src/services/biography/InMemoryBiographyService.ts
@@ -448,6 +448,15 @@ const eventHistoryMasterData: EventHistoryMaster[] = [
             ["ja", "エンタス大晦日"],
             ["en", "Akihabara ENTAS new year's eve party"],
         ]),
+        links: [
+            new EventLinkMaster({
+                name: TranslatableValues.create([
+                    ["ja", "アーカイブ"],
+                    ["en", "Live streaming archive"],
+                ]),
+                url: "https://www.twitch.tv/videos/1250667831"
+            }),
+        ]
     }),
     new EventHistoryMaster({
         date: new Date("2022-07-16"),
@@ -455,6 +464,15 @@ const eventHistoryMasterData: EventHistoryMaster[] = [
             ["ja", "エンタス夏祭り DAY1"],
             ["en", "Akihabara ENTAS summer festival DAY1"],
         ]),
+        links: [
+            new EventLinkMaster({
+                name: TranslatableValues.create([
+                    ["ja", "アーカイブ"],
+                    ["en", "Live streaming archive"],
+                ]),
+                url: "https://www.twitch.tv/videos/1535339421"
+            }),
+        ]
     }),
     new EventHistoryMaster({
         date: new Date("2022-07-31"),
@@ -495,6 +513,22 @@ const eventHistoryMasterData: EventHistoryMaster[] = [
             }),
         ]
     }),
+    new EventHistoryMaster({
+        date: new Date("2022-12-17"),
+        name: TranslatableValues.create([
+            ["ja", "エンタス忘年会"],
+            ["en", "Akihabara ENTAS year-end party"],
+        ]),
+        links: [
+            new EventLinkMaster({
+                name: TranslatableValues.create([
+                    ["ja", "アーカイブ"],
+                    ["en", "Live streaming archive"],
+                ]),
+                url: "https://www.twitch.tv/videos/1681281496"
+            }),
+        ]
+    })
 ];
 
 export const japaneseProfile: Profile = {

--- a/src/services/home/InMemoryNewsService.ts
+++ b/src/services/home/InMemoryNewsService.ts
@@ -34,30 +34,7 @@ export class NewsMaster {
     }
 }
 
-const newsMasterData: NewsMaster[] = [
-    new NewsMaster({
-        text: TranslatableValues.create([
-            ["ja", "エンタス忘年会 (2022-12-17) 出演予定"],
-            ["en", "Akihabara ENTAS year-end party (2022-12-17) "],
-        ]),
-        links: [
-            new NewsLinkMaster({
-                name: TranslatableValues.create([
-                    ["ja", "現地チケット"],
-                    ["en", "Ticket"],
-                ]),
-                url: "https://passmarket.yahoo.co.jp/event/show/detail/02wdimrm1mq21.html"
-            }),
-            new NewsLinkMaster({
-                name: TranslatableValues.create([
-                    ["ja", "Twitch(無料配信)"],
-                    ["en", "Streaming (for free)"],
-                ]),
-                url: "https://www.twitch.tv/takuya_the_bringer"
-            }),
-        ]
-    }),
-];
+const newsMasterData: NewsMaster[] = [];
 
 export class InMemoryNewsService implements NewsService {
     listNews(locale: SupportedLocale): NewsItem[] {

--- a/src/stories/components/home/News.stories.tsx
+++ b/src/stories/components/home/News.stories.tsx
@@ -1,0 +1,29 @@
+import { ComponentStory, ComponentMeta } from "@storybook/react";
+import News from "../../../components/home/News";
+
+export default {
+    title: 'components/home/News',
+    component: News,
+    parameters: {layout: 'fullscreen'}
+} as ComponentMeta<typeof News>;
+
+const Template: ComponentStory<typeof News> = (args) => <News {...args} />;
+export const withNews = Template.bind({});
+withNews.args = {
+    news: [
+        {
+            text: "タイトルのみでリンクなし"
+        },
+        {
+            text: "タイトルとリンク", 
+            links: [
+                {name: "リンク1", url: "https://locahost:6666"},
+                {name: "リンク2", url: "https://locahost:6666"},
+            ]
+        }
+    ]
+};
+export const withoutNews = Template.bind({});
+withoutNews.args = {
+    news: []
+};


### PR DESCRIPTION
Close #123

作業内容

- 2022年のエンタス忘年会をイベント出演歴へ移動
- HomeでNewsをコンポーネント化
    - 0件の場合はトルツメ
        - 0件とそうでない場合のテストコードを書こうとしたが、react testing library導入で躓いたので断念
        - Storybookに0件とそうでない場合のテンプレートを記載し、そちらでトルツメを確認できるようにはした
