### PR TITLE
Storybookのバージョンアップ

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "next-sitemap": "^2.5.28",
     "postcss": "^8.4.13",
     "postcss-loader": "^6.2.1",
-    "sb": "^6.5.13",
+    "sb": "^6.5.15",
     "tailwindcss": "^3.0.24",
     "ts-jest": "^28.0.4",
     "typescript": "4.6.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2458,19 +2458,19 @@
     ts-dedent "^2.0.0"
     util-deprecate "^1.0.2"
 
-"@storybook/cli@6.5.13":
-  version "6.5.13"
-  resolved "https://registry.yarnpkg.com/@storybook/cli/-/cli-6.5.13.tgz#693a84a50803bc24861b483e10a3a08ec738e90f"
-  integrity sha512-AU8PWJnPJzBwhG9kQZ2frGBf08c6I0VanQOchzM158Txr9at619YrwltosdSVpBNzyNkOeZoQgEJCOK0mQLvow==
+"@storybook/cli@6.5.15":
+  version "6.5.15"
+  resolved "https://registry.yarnpkg.com/@storybook/cli/-/cli-6.5.15.tgz#8cbe80e8419675bf315d1d79c313645cdcc0623b"
+  integrity sha512-oXmT6okxNsHFHTfc+fxkbnTn08ccZV1c9frVnKZt6v2+raq0B81A2DPBgh1LPZ3RHSii+U8DhbigxnyTS/CmGg==
   dependencies:
     "@babel/core" "^7.12.10"
     "@babel/preset-env" "^7.12.11"
-    "@storybook/codemod" "6.5.13"
-    "@storybook/core-common" "6.5.13"
-    "@storybook/csf-tools" "6.5.13"
-    "@storybook/node-logger" "6.5.13"
+    "@storybook/codemod" "6.5.15"
+    "@storybook/core-common" "6.5.15"
+    "@storybook/csf-tools" "6.5.15"
+    "@storybook/node-logger" "6.5.15"
     "@storybook/semver" "^7.3.2"
-    "@storybook/telemetry" "6.5.13"
+    "@storybook/telemetry" "6.5.15"
     boxen "^5.1.2"
     chalk "^4.1.0"
     commander "^6.2.1"
@@ -2527,16 +2527,24 @@
     core-js "^3.8.2"
     global "^4.4.0"
 
-"@storybook/codemod@6.5.13":
-  version "6.5.13"
-  resolved "https://registry.yarnpkg.com/@storybook/codemod/-/codemod-6.5.13.tgz#e0d56cc99c22f48870a344e144d7c2ca9f9f825a"
-  integrity sha512-XhCmhUFjYjRa6yYkWfa55/xvLjSLuyDj43symO35ph2zY8rcvJgwXxZFtF9GbWzZMkFq/4/U4j4CATTCF4PBmQ==
+"@storybook/client-logger@6.5.15":
+  version "6.5.15"
+  resolved "https://registry.yarnpkg.com/@storybook/client-logger/-/client-logger-6.5.15.tgz#0d9878af893a3493b6ee108cc097ae1436d7da4d"
+  integrity sha512-0uyxKvodq+FycGv6aUwC1wUR6suXf2+7ywMFAOlYolI4UvNj8NyU/5AfgKT5XnxYAgPmoCiAjOE700TrfHrosw==
+  dependencies:
+    core-js "^3.8.2"
+    global "^4.4.0"
+
+"@storybook/codemod@6.5.15":
+  version "6.5.15"
+  resolved "https://registry.yarnpkg.com/@storybook/codemod/-/codemod-6.5.15.tgz#46eac6089b9c5b34cfdace54df5e015995447504"
+  integrity sha512-WScvlWjzkdstVLIfYBRHVHiHKFAMkLI/QK07srPfcAt8jQ7gJzhTKeeslbFvLDDJ85P/ki3u9jHKpDNX5nkdUQ==
   dependencies:
     "@babel/types" "^7.12.11"
     "@mdx-js/mdx" "^1.6.22"
     "@storybook/csf" "0.0.2--canary.4566f4d.1"
-    "@storybook/csf-tools" "6.5.13"
-    "@storybook/node-logger" "6.5.13"
+    "@storybook/csf-tools" "6.5.15"
+    "@storybook/node-logger" "6.5.15"
     core-js "^3.8.2"
     cross-spawn "^7.0.3"
     globby "^11.0.2"
@@ -2642,6 +2650,62 @@
     util-deprecate "^1.0.2"
     webpack "4"
 
+"@storybook/core-common@6.5.15":
+  version "6.5.15"
+  resolved "https://registry.yarnpkg.com/@storybook/core-common/-/core-common-6.5.15.tgz#3ab524c7abdae52024caeb5c0349a764cb08769f"
+  integrity sha512-uits9o6qwHTPnjsNZP25f7hWmUBGRJ7FXtxxtEaNSmtiwk50KWxBaro7wt505lJ1Gb9vOhpNPhS7y3IxdsXNmQ==
+  dependencies:
+    "@babel/core" "^7.12.10"
+    "@babel/plugin-proposal-class-properties" "^7.12.1"
+    "@babel/plugin-proposal-decorators" "^7.12.12"
+    "@babel/plugin-proposal-export-default-from" "^7.12.1"
+    "@babel/plugin-proposal-nullish-coalescing-operator" "^7.12.1"
+    "@babel/plugin-proposal-object-rest-spread" "^7.12.1"
+    "@babel/plugin-proposal-optional-chaining" "^7.12.7"
+    "@babel/plugin-proposal-private-methods" "^7.12.1"
+    "@babel/plugin-proposal-private-property-in-object" "^7.12.1"
+    "@babel/plugin-syntax-dynamic-import" "^7.8.3"
+    "@babel/plugin-transform-arrow-functions" "^7.12.1"
+    "@babel/plugin-transform-block-scoping" "^7.12.12"
+    "@babel/plugin-transform-classes" "^7.12.1"
+    "@babel/plugin-transform-destructuring" "^7.12.1"
+    "@babel/plugin-transform-for-of" "^7.12.1"
+    "@babel/plugin-transform-parameters" "^7.12.1"
+    "@babel/plugin-transform-shorthand-properties" "^7.12.1"
+    "@babel/plugin-transform-spread" "^7.12.1"
+    "@babel/preset-env" "^7.12.11"
+    "@babel/preset-react" "^7.12.10"
+    "@babel/preset-typescript" "^7.12.7"
+    "@babel/register" "^7.12.1"
+    "@storybook/node-logger" "6.5.15"
+    "@storybook/semver" "^7.3.2"
+    "@types/node" "^14.0.10 || ^16.0.0"
+    "@types/pretty-hrtime" "^1.0.0"
+    babel-loader "^8.0.0"
+    babel-plugin-macros "^3.0.1"
+    babel-plugin-polyfill-corejs3 "^0.1.0"
+    chalk "^4.1.0"
+    core-js "^3.8.2"
+    express "^4.17.1"
+    file-system-cache "^1.0.5"
+    find-up "^5.0.0"
+    fork-ts-checker-webpack-plugin "^6.0.4"
+    fs-extra "^9.0.1"
+    glob "^7.1.6"
+    handlebars "^4.7.7"
+    interpret "^2.2.0"
+    json5 "^2.1.3"
+    lazy-universal-dotenv "^3.0.1"
+    picomatch "^2.3.0"
+    pkg-dir "^5.0.0"
+    pretty-hrtime "^1.0.3"
+    resolve-from "^5.0.0"
+    slash "^3.0.0"
+    telejson "^6.0.8"
+    ts-dedent "^2.0.0"
+    util-deprecate "^1.0.2"
+    webpack "4"
+
 "@storybook/core-events@6.5.13":
   version "6.5.13"
   resolved "https://registry.yarnpkg.com/@storybook/core-events/-/core-events-6.5.13.tgz#a8c0cc92694f09981ca6501d5c5ef328db18db8a"
@@ -2712,6 +2776,26 @@
   version "6.5.13"
   resolved "https://registry.yarnpkg.com/@storybook/csf-tools/-/csf-tools-6.5.13.tgz#cb5cd26083a594bf31b19a66a250ad94863822f6"
   integrity sha512-63Ev+VmBqzwSwfUzbuXOLKBD5dMTK2zBYLQ9anTVw70FuTikwTsGIbPgb098K0vsxRCgxl7KM7NpivHqtZtdjw==
+  dependencies:
+    "@babel/core" "^7.12.10"
+    "@babel/generator" "^7.12.11"
+    "@babel/parser" "^7.12.11"
+    "@babel/plugin-transform-react-jsx" "^7.12.12"
+    "@babel/preset-env" "^7.12.11"
+    "@babel/traverse" "^7.12.11"
+    "@babel/types" "^7.12.11"
+    "@storybook/csf" "0.0.2--canary.4566f4d.1"
+    "@storybook/mdx1-csf" "^0.0.1"
+    core-js "^3.8.2"
+    fs-extra "^9.0.1"
+    global "^4.4.0"
+    regenerator-runtime "^0.13.7"
+    ts-dedent "^2.0.0"
+
+"@storybook/csf-tools@6.5.15":
+  version "6.5.15"
+  resolved "https://registry.yarnpkg.com/@storybook/csf-tools/-/csf-tools-6.5.15.tgz#dc5d0fe946c25d60bf201e5180c4fc81b24f763b"
+  integrity sha512-2LwSD7yE/ccXBc58K4vdKw/oJJg6IpC4WD51rBt2mAl5JUCkxhOq7wG/Z8Wy1lZw2LVuKNTmjVou5blGRI/bTg==
   dependencies:
     "@babel/core" "^7.12.10"
     "@babel/generator" "^7.12.11"
@@ -2828,6 +2912,17 @@
   version "6.5.13"
   resolved "https://registry.yarnpkg.com/@storybook/node-logger/-/node-logger-6.5.13.tgz#f4833ae220efe841747c4fead26419d6625af8d9"
   integrity sha512-/r5aVZAqZRoy5FyNk/G4pj7yKJd3lJfPbAaOHVROv2IF7PJP/vtRaDkcfh0g2U6zwuDxGIqSn80j+qoEli9m5A==
+  dependencies:
+    "@types/npmlog" "^4.1.2"
+    chalk "^4.1.0"
+    core-js "^3.8.2"
+    npmlog "^5.0.1"
+    pretty-hrtime "^1.0.3"
+
+"@storybook/node-logger@6.5.15":
+  version "6.5.15"
+  resolved "https://registry.yarnpkg.com/@storybook/node-logger/-/node-logger-6.5.15.tgz#d99695e8d5f8cf434e8fdcca719b5b5fa5c88e2e"
+  integrity sha512-LQjjbfMuUXm7wZTBKb+iGeCNnej4r1Jb2NxG3Svu2bVhaoB6u33jHAcbmhXpXW1jghzW3kQwOU7BoLuJiRRFIw==
   dependencies:
     "@types/npmlog" "^4.1.2"
     chalk "^4.1.0"
@@ -2992,6 +3087,24 @@
   dependencies:
     "@storybook/client-logger" "6.5.13"
     "@storybook/core-common" "6.5.13"
+    chalk "^4.1.0"
+    core-js "^3.8.2"
+    detect-package-manager "^2.0.1"
+    fetch-retry "^5.0.2"
+    fs-extra "^9.0.1"
+    global "^4.4.0"
+    isomorphic-unfetch "^3.1.0"
+    nanoid "^3.3.1"
+    read-pkg-up "^7.0.1"
+    regenerator-runtime "^0.13.7"
+
+"@storybook/telemetry@6.5.15":
+  version "6.5.15"
+  resolved "https://registry.yarnpkg.com/@storybook/telemetry/-/telemetry-6.5.15.tgz#852050c1e54bf704a104e47e4e498d999096e0e7"
+  integrity sha512-WHMRG6xMkEGscn1q4SotwzV8hxM1g3zHyXPN77iosY5zpOIn/qAzvkmW28V1DPH9jPWMZMizBgG1TIQvUpduXg==
+  dependencies:
+    "@storybook/client-logger" "6.5.15"
+    "@storybook/core-common" "6.5.15"
     chalk "^4.1.0"
     core-js "^3.8.2"
     detect-package-manager "^2.0.1"
@@ -11585,12 +11698,12 @@ sane@^4.0.3:
     minimist "^1.1.1"
     walker "~1.0.5"
 
-sb@^6.5.13:
-  version "6.5.13"
-  resolved "https://registry.yarnpkg.com/sb/-/sb-6.5.13.tgz#4d986b07d0ed8ffb9e64f0e7fa1ac4d6c52d7406"
-  integrity sha512-4NY9igM9Nz2Ha+e2MNd0spMTXDP6xxG8l5ANkQj1sRRf7cp3B8ut1QRT0n0M3QRx8+bvtDWLyE9Tz7m0pgeYeA==
+sb@^6.5.15:
+  version "6.5.15"
+  resolved "https://registry.yarnpkg.com/sb/-/sb-6.5.15.tgz#a621cd4199ebd64b0bd75e109109e91023b71321"
+  integrity sha512-trZ+5XsY/8rWchalotZekuBUiKUEHS47k4cyGbW08y206RbnBv/7z2AAut6K9wLsSNcCmJgltd2PMpdei4LRHw==
   dependencies:
-    "@storybook/cli" "6.5.13"
+    "@storybook/cli" "6.5.15"
 
 scheduler@^0.23.0:
   version "0.23.0"


### PR DESCRIPTION
refs https://github.com/01G271BR9H8WH1VNE8QHKYGDCX/yorudokimayu-info/security/dependabot/7


やったこと

* Storybookを6.5.15に更新
    * [6.5.14](https://github.com/storybookjs/storybook/releases/tag/v6.5.14)でloader-utilsが2.0.4に更新された