### PR TITLE
コンポーネント内にベタ書きだった記述について共通部分を定義化

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yorudokimayu-info",
-  "version": "1.2.23",
+  "version": "1.2.24",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/src/components/biography/CollaborationCard.tsx
+++ b/src/components/biography/CollaborationCard.tsx
@@ -2,27 +2,26 @@ import React from "react";
 import DateLabel from "./DateLabel";
 import { Collaboration } from "../../services/biography/BiographyService";
 import LinkList from "../common/LinkList";
+import { Padding } from "../../constants/tailwind";
 
 type Props = {
     collaboration: Collaboration;    
 };
 
 const CollaborationCard: React.FC<Props> = ({collaboration}) => {
-    return <article className="p-2">
+    return <article className={`${Padding.Small}`}>
         <div className="flex flex-wrap space-x-4">
             <DateLabel date={collaboration.date} />
-            <span className="text-sm">
+            <span>
                 {collaboration.product.artist}
                 {collaboration.product.artist.length > 0 ? " " : ""}
                 {collaboration.product.name}
             </span>
+            <span>{collaboration.partOfTheWork}</span>
         </div>
-        <div className="flex flex-wrap space-x-4 jusitfy-start items-center">
-            <span className="text-sm">{collaboration.partOfTheWork}</span>
-            { collaboration.links.length > 0 && 
-                <LinkList linkItems={collaboration.links} />
-            }
-        </div>
+        { collaboration.links.length > 0 && 
+            <LinkList linkItems={collaboration.links} />
+        }
     </article>;
 };
 

--- a/src/components/biography/EventHistoryCard.tsx
+++ b/src/components/biography/EventHistoryCard.tsx
@@ -2,13 +2,14 @@ import React from "react";
 import DateLabel from "./DateLabel";
 import { EventHistory } from "../../services/biography/BiographyService";
 import LinkList from "../common/LinkList";
+import { Padding } from "../../constants/tailwind";
 
 type Props = {
     eventHistory: EventHistory;
 };
 
 const EventHistoryCard : React.FC<Props> = ({eventHistory}: Props) => {
-    return <article className="p-2">
+    return <article className={`${Padding.Small}`}>
         <div className="flex space-x-4 justify-start items-center">
             <DateLabel date={eventHistory.date} />
             <span>{eventHistory.name}</span>

--- a/src/components/common/PageTitle.tsx
+++ b/src/components/common/PageTitle.tsx
@@ -1,11 +1,12 @@
 import React from "react";
+import { FontSize } from "../../constants/tailwind";
 
 type Props = {
     text: string;
 };
 
 const PageTitle: React.FC<Props> = ({text}) => {
-    return <h1 className="my-4 text-2xl md:text-4xl">{text}</h1>
+    return <h1 className={`my-4 ${FontSize.PageHeader}`}>{text}</h1>
 };
 
 export default PageTitle;

--- a/src/components/common/SectionTitle.tsx
+++ b/src/components/common/SectionTitle.tsx
@@ -1,11 +1,12 @@
 import React from "react";
+import { FontSize } from "../../constants/tailwind";
 
 type Props = {
     text: string;
 };
 
 const SectionTitle: React.FC<Props> = ({text}) => {
-    return <h2 className="my-4 text-xl md:text-2xl">{text}</h2>
+    return <h2 className={`my-4 ${FontSize.SectionHeader}`}>{text}</h2>
 };
 
 export default SectionTitle;

--- a/src/components/discography/ProductCard.tsx
+++ b/src/components/discography/ProductCard.tsx
@@ -4,6 +4,7 @@ import GenreLabel from "./GenreLabel";
 import BorderLinkButton from "./BorderLinkButton";
 import FilledLinkButton from "./FilledLinkButton";
 import { ProductSummary } from "../../services/discography/ProductService"; 
+import { FontSize, Padding } from "../../constants/tailwind";
 
 type Props = {
     productSummary: ProductSummary;
@@ -11,8 +12,8 @@ type Props = {
 
 const ProductCard: React.FC<Props> = ({productSummary}) => {
     return <>
-        <article className="p-4">
-            <h3 className="text-xl font-bold">{productSummary.name}</h3>
+        <article className={`${Padding.Middle}`}>
+            <h3 className={`${FontSize.ProductName} font-bold`}>{productSummary.name}</h3>
             <div className="flex space-x-4">
                 <DateOfRleaseLabel dateOfRelease={productSummary.dateOfRelease} />
                 <GenreLabel genre={productSummary.genre} />
@@ -27,7 +28,7 @@ const ProductCard: React.FC<Props> = ({productSummary}) => {
             </div>
             { productSummary.mvLinks.length > 0 && 
                 <div className="my-2 text-center">
-                    <span className="p-2">Music video</span>
+                    <span className={`${Padding.Small}`}>Music video</span>
                     <div className="grid grid-cols gap-2">
                         {productSummary.mvLinks.map((linkItem, index) => <FilledLinkButton key={index} linkItem={linkItem} /> )}
                     </div>
@@ -35,7 +36,7 @@ const ProductCard: React.FC<Props> = ({productSummary}) => {
             }
             { productSummary.storeLinks.length > 0 && 
                 <div className="my-2 text-center">
-                    <span className="p-2">Store</span>
+                    <span className={`${Padding.Small}`}>Store</span>
                     <div className="grid grid-cols gap-2">
                         {productSummary.storeLinks.map((linkItem, index) => <BorderLinkButton key={index} linkItem={linkItem} /> )}
                     </div>
@@ -43,14 +44,12 @@ const ProductCard: React.FC<Props> = ({productSummary}) => {
             }
             { productSummary.supplementalInformationLinks != null && productSummary.supplementalInformationLinks.length > 0 && 
                 <div className="my-2 text-center">
-                    <span className="p-2">Supplemental information</span>
+                    <span className={`${Padding.Small}`}>Supplemental information</span>
                     <div className="grid grid-cols gap-2">
                         {productSummary.supplementalInformationLinks.map((linkItem, index) => <BorderLinkButton key={index} linkItem={linkItem} /> )}
                     </div>
-
                 </div>
             }
-            
         </article>
     </>
 };

--- a/src/constants/tailwind.ts
+++ b/src/constants/tailwind.ts
@@ -1,3 +1,15 @@
-export const Color = {
-    Link: 'indigo-800',
-} as const;
+export enum Color {
+    Link = 'indigo-800',
+};
+
+export enum Padding {
+    Small = 'p-2',
+    Middle = 'p-4',
+};
+
+export enum FontSize {
+    PageHeader = 'text-2xl md:text-4xl',
+    SectionHeader = 'text-xl md:text-2xl',
+    ProductName = 'text-large',
+    Small = 'text-sm',
+}


### PR DESCRIPTION
refs #43 

- パディングとフォントサイズの定義を導入
- Biography の コラボのマークアップについて文書構造を修正
    - 日付 / コラボ先 / 担当 を1まとめにした
