### PR TITLE
amplify.ymlのnodeバージョン指定を削除

### DIFF
--- a/amplify.yml
+++ b/amplify.yml
@@ -3,8 +3,6 @@ frontend:
   phases:
     preBuild:
       commands:
-        - nvm install 16
-        - nvm use 16
         - yarn install
     build:
       commands:


### PR DESCRIPTION
Close #197 

* AWS Amplify側の設定でNode.jsは18系を使うようになっていたが、
  amplify.ymlは16系を使うような記述だったためこの記述を削除した