### PR TITLE
Newsを削除。 Biographyに2023秋M3の情報を追加

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yorudokimayu-info",
-  "version": "1.2.41",
+  "version": "1.2.42",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/src/services/biography/InMemoryBiographyService.ts
+++ b/src/services/biography/InMemoryBiographyService.ts
@@ -238,11 +238,11 @@ const collaborationMasterData: CollaborationMaster[] = [
         date: new Date("2023-04-30"),
         productName: TranslatableValues.create([
             ["ja", "パンケーキキャッツ サニーソング"],
-            ["en", "PancakeCats sunnysong"]
+            ["en", "PancakeCats Sunny Song"]
         ]),
         partOfTheWork: TranslatableValues.create([
             ["ja", "Tr1 サニーソング (feat.拠鳥きまゆ) 歌唱"],
-            ["en", "Vocal Tr1 sunnysong (feat. Yorudo Kimayu)"],
+            ["en", "Vocal Tr1 Sunny Song (feat. Yorudo Kimayu)"],
         ]),
         links: [
             new LinkMaster({
@@ -259,6 +259,7 @@ const collaborationMasterData: CollaborationMaster[] = [
                 ]),
                 url: TranslatableValues.createUnifiedStatement("https://youtu.be/H5zN6zqcPKE"),
             }),
+            LinkMaster.createForTuneCore({id: "SMzvnrya"}),
         ],
     }),
     new CollaborationMaster({
@@ -274,6 +275,33 @@ const collaborationMasterData: CollaborationMaster[] = [
         links: [
             LinkMaster.createForTuneCore({id: '66EeHazf'}),
             LinkMaster.createMusicVideoOnYouTube({id: 'NrdD9jrN1Jg'}),
+        ],
+    }),
+    new CollaborationMaster({
+        date: new Date('2023-10-30'),
+        productName: TranslatableValues.create([
+            ["ja", "パンケーキキャッツ Re:collection"],
+            ["en", "PancakeCats Re:collection"]
+        ]),
+        partOfTheWork: TranslatableValues.create([
+            ["ja", "Tr.06 シゲキ的ドラスティックチューン(feat.拠鳥きまゆ) 歌唱"],
+            ["en", "Vocal Tr.06 シゲキ的ドラスティックチューン(feat.拠鳥きまゆ) (English translation is not available)"],
+        ]),
+        links: [
+            new LinkMaster({
+                name: TranslatableValues.create([
+                    ["ja", "特設サイト"],
+                    ["en", "Web site"],
+                ]),
+                url: TranslatableValues.createUnifiedStatement("https://re-collection.studio.site/"),
+            }),
+            new LinkMaster({
+                name: TranslatableValues.create([
+                    ["ja", "クロスフェードデモ"],
+                    ["en", "Crossfade Demo"],
+                ]),
+                url: TranslatableValues.createUnifiedStatement("https://youtu.be/yUUtXN25b9Q"),
+            }),
         ],
     }),
 ];
@@ -527,6 +555,22 @@ const eventHistoryMasterData: EventHistoryMaster[] = [
             }),
         ],
     }),
+    new EventHistoryMaster({
+        name: TranslatableValues.create([
+            ['ja', 'わくわく！VTuberひろば Vol.35 ミュージックLIVE'],
+            ['en', 'WAKUWAKU VTuber HIROBA Vol.35 music live'],
+        ]),
+        date: new Date('2023-10-21'),
+        links: [
+            new LinkMaster({
+                url: TranslatableValues.createUnifiedStatement('https://www.youtube.com/live/QsQogxbnXUQ'),
+                name: TranslatableValues.create([
+                    ['ja', 'アーカイブ'],
+                    ['en', 'Live streaming archive'],
+                ]),
+            })
+        ]
+    })
 ];
 
 export const japaneseProfile: Profile = {

--- a/src/services/home/InMemoryNewsService.ts
+++ b/src/services/home/InMemoryNewsService.ts
@@ -20,53 +20,7 @@ export class NewsMaster {
     }
 }
 
-const newsMasterData: NewsMaster[] = [
-    new NewsMaster({
-        text: TranslatableValues.create([
-            ['ja', '2023-10-07 拠鳥きまゆ 1st Oneman Live「PENGUIN A LIVE」'],
-            ['en', '2023-10-07 Kimayu Yorudo 1st solo concert "PENGUIN A LIVE"']
-        ]),
-        links: [
-            new LinkMaster({
-                url: TranslatableValues.createUnifiedStatement('https://www.zan-live.com/live/detail/10311'),
-                name: TranslatableValues.create([
-                    ['ja', '配信 Z-aN (アーカイブは2023-10-31まで視聴可能)'],
-                    ['en', 'Streaming Z-aN (The archive will be available until 2023-10-31)'],
-                ]),
-            }),
-            new LinkMaster({
-                url: TranslatableValues.createUnifiedStatement('https://panora.tokyo/archives/73141'),
-                name: TranslatableValues.create([
-                    ['ja', 'ライブレポート (ネタバレ注意)'],
-                    ['en', 'Report on PANORA (spoiler alert)'],
-                ])
-            })
-        ]
-    }),
-    new NewsMaster({
-        text: TranslatableValues.createUnifiedStatement('2023-10-10 New song "PENGUIN ALIVE"'),
-        links: [
-            LinkMaster.createMusicVideoOnYouTube({id: "jM5AdQGVZ4g"}),
-            LinkMaster.createForTuneCore({id: "vMh6myS4"}),
-            LinkMaster.createForOfficialStore({id: "5153499"}),
-        ]
-    }), 
-    new NewsMaster({
-        text: TranslatableValues.create([
-            ['ja', '2023-10-21 わくわく！VTuberひろば Vol.35 ミュージックLIVE'],
-            ['en', '2023-10-21 WAKUWAKU VTuber HIROBA Vol.35 music live'],
-        ]),
-        links: [
-            new LinkMaster({
-                url: TranslatableValues.createUnifiedStatement('https://www.youtube.com/@AkihabaraLab'),
-                name: TranslatableValues.create([
-                    ['ja', '配信 AkihabaraLab YouTubeチャネル'],
-                    ['en', 'Streaming on AkihabaraLab YouTube channel'],
-                ]),
-            })
-        ],
-    })
-];
+const newsMasterData: NewsMaster[] = [];
 
 export class InMemoryNewsService implements NewsService {
     listNews(locale: SupportedLocale): NewsItem[] {


### PR DESCRIPTION
Close #217 

* Newsを空にした
* Biographyに諸々情報追加・編集
    * わくV
    * サニーソングのTuneCoreのURL記載 & TuneCoreで正式な英訳がわかったので修正
    * シゲキ的ドラスティックチューンを追加