### PR TITLE
superjsonを削除

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,4 @@
 {
   "presets": ["next/babel"],
-  "plugins": ["superjson-next"]
+  "plugins": []
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yorudokimayu-info",
-  "version": "1.2.46",
+  "version": "1.2.47",
   "private": true,
   "scripts": {
     "dev": "next dev",
@@ -20,8 +20,7 @@
     "next": "13.2.4",
     "next-seo": "^5.15.0",
     "react": "18.2.0",
-    "react-dom": "18.2.0",
-    "superjson": "^1.13.3"
+    "react-dom": "18.2.0"
   },
   "devDependencies": {
     "@babel/core": "^7.21.3",
@@ -39,7 +38,6 @@
     "@types/react-dom": "18.0.11",
     "autoprefixer": "^10.4.14",
     "babel-loader": "^9.1.2",
-    "babel-plugin-superjson-next": "^0.4.5",
     "cypress": "13.3.0",
     "eslint": "8.50.0",
     "eslint-config-next": "13.2.4",

--- a/src/components/biography/DateLabel.tsx
+++ b/src/components/biography/DateLabel.tsx
@@ -1,12 +1,11 @@
 import React from "react";
-import { format } from "date-fns";
 
 type Props = {
-    date: Date;
+    date: string; // yyyy-MM-dd
 };
 
 const DateLabel: React.FC<Props> = ({date}) => {
-    return <span className="text-slate-800 text-sm text-center">{format(date, "yyyy-MM-dd")}</span>
+    return <span className="text-slate-800 text-sm text-center">{date}</span>
 };
 
 export default DateLabel;

--- a/src/components/discography/DateOfReleaseLabel.tsx
+++ b/src/components/discography/DateOfReleaseLabel.tsx
@@ -1,12 +1,11 @@
 import React from "react";
-import { format } from "date-fns";
 
 type Props = {
-    dateOfRelease: Date;
+    dateOfRelease: string; // yyyy-MM-dd
 };
 
 const DateOfRleaseLabel: React.FC<Props> = ({dateOfRelease}) => {
-    return <span className="text-slate-600 text-base">{format(dateOfRelease, "yyyy-MM-dd")}</span>
+    return <span className="text-slate-600 text-base">{dateOfRelease}</span>
 };
 
 export default DateOfRleaseLabel;

--- a/src/services/biography/BiographyService.ts
+++ b/src/services/biography/BiographyService.ts
@@ -14,14 +14,14 @@ export type CollaborationProduct = {
 }
 
 export type Collaboration = {
-    date: Date;
+    date: string; // yyyy-MM-dd
     product: CollaborationProduct;
     partOfTheWork: string;
     links: LinkItem[];
 };
 
 export type EventHistory = {
-    date: Date;
+    date: string; // yyyy-MM-dd
     name: string;
     links?: LinkItem[];
 };

--- a/src/services/biography/BiographyService.ts
+++ b/src/services/biography/BiographyService.ts
@@ -3,7 +3,7 @@ import { LinkItem } from "../common/Link";
 
 export type Profile = {
     name: string;
-    nameCaption?: string;
+    nameCaption: string | null;
     introductions: string[];
     activities: string[];
 };
@@ -23,7 +23,7 @@ export type Collaboration = {
 export type EventHistory = {
     date: string; // yyyy-MM-dd
     name: string;
-    links?: LinkItem[];
+    links: LinkItem[];
 };
 
 export interface BiographyService {

--- a/src/services/biography/InMemoryBiographyService.test.ts
+++ b/src/services/biography/InMemoryBiographyService.test.ts
@@ -25,7 +25,7 @@ describe('CollaborationMaster', () => {
             ],
         });
         expect(master.getCollaboration("ja")).toEqual({
-            date: new Date("2021-04-01"),
+            date: "2021-04-01",
             product: {
                 name: "Bloomer",
                 artist: "#ぶいっと"
@@ -38,7 +38,7 @@ describe('CollaborationMaster', () => {
             ]
         });
         expect(master.getCollaboration("en")).toEqual({
-            date: new Date("2021-04-01"),
+            date: "2021-04-01",
             product: {
                 name: "Bloomer",
                 artist: "#Vtuber_Motto"
@@ -72,7 +72,7 @@ describe('EventHistoryMaster', () => {
             ],
         });
         expect(master.getEventHistory("ja")).toEqual({
-            date: new Date("2021-11-20"),
+            date: "2021-11-20",
             name: "#ぶいじゃむ vol.1",
             links: [
                 {
@@ -82,7 +82,7 @@ describe('EventHistoryMaster', () => {
             ]
         });
         expect(master.getEventHistory("en")).toEqual({
-            date: new Date("2021-11-20"),
+            date: "2021-11-20",
             name: "#V-jam vol.1 (Copy band sessions of major artists)",
             links: [
                 {

--- a/src/services/biography/InMemoryBiographyService.ts
+++ b/src/services/biography/InMemoryBiographyService.ts
@@ -1,3 +1,4 @@
+import { format } from "date-fns";
 import { SUPPORTED_LOCALES, SupportedLocale } from "../../constants/i18n";
 import { LinkMaster } from "../common/Link";
 import { createBoothUrl } from "../i18n/Booth";
@@ -26,7 +27,7 @@ export class CollaborationMaster {
     }
     getCollaboration(locale: SupportedLocale): Collaboration {
         return {
-            date: this.date,
+            date: format(this.date, 'yyyy-MM-dd'),
             product: {
                 name: this.productName.getLocalizedValue(locale),
                 artist: this.productArtist?.getLocalizedValue(locale) || "",
@@ -322,7 +323,7 @@ export class EventHistoryMaster {
     }
     getEventHistory(locale: SupportedLocale): EventHistory {
         return {
-            date: this.date,
+            date: format(this.date, 'yyyy-MM-dd'),
             name: this.name.getLocalizedValue(locale),
             links: this.links.map((linkMaster) => {
                 return linkMaster.getLinkItem(locale)    

--- a/src/services/biography/InMemoryBiographyService.ts
+++ b/src/services/biography/InMemoryBiographyService.ts
@@ -597,7 +597,7 @@ export const japaneseProfile: Profile = {
 
 export const englishProfile: Profile = {
     name: "Kimayu Yorudo",
-    nameCaption: undefined,
+    nameCaption: null,
     introductions: [
         "She is a virtual artist who focus on rock music.",
         "She respects PENGUIN RESEARCH and posts covers of PENGUIN RESEARCH and kemu songs on her YouTube channel.",

--- a/src/services/discography/InMemoryProductService.ts
+++ b/src/services/discography/InMemoryProductService.ts
@@ -1,3 +1,4 @@
+import { format } from "date-fns";
 import { SupportedLocale } from "../../constants/i18n";
 import { LinkMaster } from "../common/Link";
 import { TranslatableValues } from "../i18n/TranslatableValues";
@@ -43,7 +44,7 @@ export class ProductMaster {
             name: this.name.getLocalizedValue(locale),
             kind: this.kind,
             genre: this.genre,
-            dateOfRelease: this.dateOfRelease,
+            dateOfRelease: format(this.dateOfRelease, 'yyyy-MM-dd'),
             description: this.description?.getLocalizedValue(locale) || "",
             credits: this.credits.map((creditMaster) => {
                 return creditMaster.getLocalizedValue(locale);

--- a/src/services/discography/InMemoryProductService.ts
+++ b/src/services/discography/InMemoryProductService.ts
@@ -55,9 +55,9 @@ export class ProductMaster {
             storeLinks: this.storeLinks.map((LinkMaster) => {
                 return LinkMaster.getLinkItem(locale);
             }),
-            supplementalInformationLinks: this.supplementalInformationLinks?.map((supplementalInformationLinkMaster) => {
+            supplementalInformationLinks: this.supplementalInformationLinks ? this.supplementalInformationLinks.map((supplementalInformationLinkMaster) => {
                 return supplementalInformationLinkMaster.getLinkItem(locale);
-            }),
+            }) : [],
         };
     }
 }

--- a/src/services/discography/ProductService.ts
+++ b/src/services/discography/ProductService.ts
@@ -12,7 +12,7 @@ export type ProductSummary = {
     name: string;
     kind: ProductKind;
     genre: Genre;
-    dateOfRelease: Date;
+    dateOfRelease: string; // yyyy-MM-dd;
     description: string;
     credits: string[];
     mvLinks: LinkItem[];

--- a/src/services/discography/ProductService.ts
+++ b/src/services/discography/ProductService.ts
@@ -17,7 +17,7 @@ export type ProductSummary = {
     credits: string[];
     mvLinks: LinkItem[];
     storeLinks: LinkItem[];
-    supplementalInformationLinks?: LinkItem[];
+    supplementalInformationLinks: LinkItem[];
 };
 
 export interface ProductService {

--- a/src/stories/components/discography/DateOfReleaseLabel.stories.tsx
+++ b/src/stories/components/discography/DateOfReleaseLabel.stories.tsx
@@ -9,4 +9,4 @@ export default {
 
 const Template: ComponentStory<typeof DateOfRleaseLabel> = (args) => <DateOfRleaseLabel {...args} />;
 export const label = Template.bind({});
-label.args = { dateOfRelease: new Date("2020-10-10")};
+label.args = { dateOfRelease: "2020-10-10"};

--- a/src/stories/components/discography/ProductCard.stories.tsx
+++ b/src/stories/components/discography/ProductCard.stories.tsx
@@ -15,7 +15,7 @@ productCard.args = {
         name: "sparkler",
         kind: "EP",
         genre: "Alternative",
-        dateOfRelease: new Date("2022-04-24"),
+        dateOfRelease: "2022-04-24",
         description: "1st EP M3-2022春 お-07a頒布で頒布・Boothにて販売",
         credits: [
             "作曲・Tr2作詞 マッチ",

--- a/src/stories/components/discography/ProductCard.stories.tsx
+++ b/src/stories/components/discography/ProductCard.stories.tsx
@@ -27,6 +27,7 @@ productCard.args = {
         ],
         storeLinks: [
             {name: "Official store", url: "https://461okmy.booth.pm/items/3756256"},
-        ]
+        ],
+        supplementalInformationLinks: [],
     }
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -284,13 +284,6 @@
   dependencies:
     "@babel/types" "^7.23.0"
 
-"@babel/helper-module-imports@^7.13.12":
-  version "7.18.6"
-  resolved "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.18.6.tgz#1e3ebdbbd08aad1437b428c50204db13c5a3ca6e"
-  integrity sha512-0NFvs3VkuSYbFi1x2Vd6tKrywq+z/cLeYC/RJNFrIX/30Bf5aiGYbtvGXolEktzJH8o5E5KJ3tT+nkxuuZFVlA==
-  dependencies:
-    "@babel/types" "^7.18.6"
-
 "@babel/helper-module-imports@^7.18.6":
   version "7.21.4"
   resolved "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.21.4.tgz#ac88b2f76093637489e718a90cec6cf8a9b029af"
@@ -1466,7 +1459,7 @@
     "@babel/helper-validator-identifier" "^7.19.1"
     to-fast-properties "^2.0.0"
 
-"@babel/types@^7.13.17", "@babel/types@^7.20.0", "@babel/types@^7.4.4":
+"@babel/types@^7.20.0", "@babel/types@^7.4.4":
   version "7.21.3"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.21.3.tgz#4865a5357ce40f64e3400b0f3b737dc6d4f64d05"
   integrity sha512-sBGdETxC+/M4o/zKC0sl6sjWv62WFR/uzxrJ6uYyMLZOUlPnwzw0tKgVHOXxaAd5l2g8pEDM5RZ495GPQI77kg==
@@ -4515,15 +4508,6 @@ babel-plugin-react-docgen@^4.2.1:
     lodash "^4.17.15"
     react-docgen "^5.0.0"
 
-babel-plugin-superjson-next@^0.4.5:
-  version "0.4.5"
-  resolved "https://registry.yarnpkg.com/babel-plugin-superjson-next/-/babel-plugin-superjson-next-0.4.5.tgz#988ca073fb2059f1dc0c2d439b42e82a478b8cd2"
-  integrity sha512-k7S99Qpsbi3OSdlCMXEiklzxepM6QbYEIUsrjgSkpx+ksT0iNfdY2r1kCzBK2UjG8fLN6NZEKpDA8XpG2pbDSA==
-  dependencies:
-    "@babel/helper-module-imports" "^7.13.12"
-    "@babel/types" "^7.13.17"
-    hoist-non-react-statics "^3.3.2"
-
 babel-preset-current-node-syntax@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-1.0.1.tgz#b4399239b89b2a011f9ddbe3e4f401fc40cff73b"
@@ -5222,13 +5206,6 @@ cookie@0.5.0:
   version "0.5.0"
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.5.0.tgz#d1f5d71adec6558c58f389987c366aa47e994f8b"
   integrity sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==
-
-copy-anything@^3.0.2:
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/copy-anything/-/copy-anything-3.0.3.tgz#206767156f08da0e02efd392f71abcdf79643559"
-  integrity sha512-fpW2W/BqEzqPp29QS+MwwfisHCQZtiduTe/m8idFo0xbti9fIZ2WVhAsCv4ggFVH3AgCkVdpoOCtQC6gBrdhjw==
-  dependencies:
-    is-what "^4.1.8"
 
 core-js-compat@^3.31.0, core-js-compat@^3.32.2:
   version "3.32.2"
@@ -7118,13 +7095,6 @@ hmac-drbg@^1.0.1:
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.1"
 
-hoist-non-react-statics@^3.3.2:
-  version "3.3.2"
-  resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz#ece0acaf71d62c2969c2ec59feff42a4b1a85b45"
-  integrity sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==
-  dependencies:
-    react-is "^16.7.0"
-
 hosted-git-info@^2.1.4:
   version "2.8.9"
   resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.8.9.tgz#dffc0bf9a21c02209090f2aa69429e1414daf3f9"
@@ -7599,11 +7569,6 @@ is-weakset@^2.0.1:
   dependencies:
     call-bind "^1.0.2"
     get-intrinsic "^1.1.1"
-
-is-what@^4.1.8:
-  version "4.1.8"
-  resolved "https://registry.yarnpkg.com/is-what/-/is-what-4.1.8.tgz#0e2a8807fda30980ddb2571c79db3d209b14cbe4"
-  integrity sha512-yq8gMao5upkPoGEU9LsB2P+K3Kt8Q3fQFCGyNCWOAnJAMzEXVV9drYb0TXr42TTliLLhKIBvulgAXgtLLnwzGA==
 
 is-wsl@^2.2.0:
   version "2.2.0"
@@ -9706,7 +9671,7 @@ react-is@18.1.0:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-18.1.0.tgz#61aaed3096d30eacf2a2127118b5b41387d32a67"
   integrity sha512-Fl7FuabXsJnV5Q1qIOQwx/sagGF18kogb4gpfcG4gjLBWO0WDiiz1ko/ExayuxE7InyQkBLkxRFG5oxY6Uu3Kg==
 
-react-is@^16.13.1, react-is@^16.7.0:
+react-is@^16.13.1:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
@@ -10584,13 +10549,6 @@ styled-jsx@5.1.1:
   integrity sha512-pW7uC1l4mBZ8ugbiZrcIsiIvVx1UmTfw7UkC3Um2tmfUq9Bhk8IiyEIPl6F8agHgjzku6j0xQEZbfA5uSgSaCw==
   dependencies:
     client-only "0.0.1"
-
-superjson@^1.13.3:
-  version "1.13.3"
-  resolved "https://registry.yarnpkg.com/superjson/-/superjson-1.13.3.tgz#3bd64046f6c0a47062850bb3180ef352a471f930"
-  integrity sha512-mJiVjfd2vokfDxsQPOwJ/PtanO87LhpYY88ubI5dUB1Ab58Txbyje3+jpm+/83R/fevaq/107NNhtYBLuoTrFg==
-  dependencies:
-    copy-anything "^3.0.2"
 
 supports-color@^5.3.0:
   version "5.5.0"


### PR DESCRIPTION
ref #225

- Dateの代わりにIOS8601形式の文字列を使う
- undefinedの代わりにnullを使う
- 配列のプロパティはnull許容せずに空配列を使う

結果、getServerSidePropsでのsuperjsonによるシリアライズが不要になった
storybookではまだBabelでのトランスパイルが必要なので、.babelrcは削除できてない