### PR TITLE
Newsとイベント履歴を更新

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yorudokimayu-info",
-  "version": "1.2.48",
+  "version": "1.2.49",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/src/services/biography/InMemoryBiographyService.ts
+++ b/src/services/biography/InMemoryBiographyService.ts
@@ -572,6 +572,19 @@ const eventHistoryMasterData: EventHistoryMaster[] = [
                 ]),
             })
         ]
+    }),
+    new EventHistoryMaster({
+        name: TranslatableValues.createUnifiedStatement("Vack-ON!! vol.2"),
+        date: new Date('2023-12-29'),
+        links: [
+            new LinkMaster({
+                url: TranslatableValues.createUnifiedStatement("https://zaiko.io/event/360813"), 
+                name: TranslatableValues.create([
+                    ['ja', 'アーカイブ'],
+                    ['en', 'Live streaming archive'],
+                ]),
+            })
+        ]
     })
 ];
 

--- a/src/services/home/InMemoryNewsService.ts
+++ b/src/services/home/InMemoryNewsService.ts
@@ -23,28 +23,6 @@ export class NewsMaster {
 const newsMasterData: NewsMaster[] = [
     new NewsMaster({
         text: TranslatableValues.create([
-            ["ja", "2023-12-24 VIRTUALHOLIC歌枠リレー"],
-            ["en", "2023-12-24 VIRTUALHOLIC Singing Stream Relay"]
-        ]),
-        links: [
-            new LinkMaster({
-                name: TranslatableValues.create([
-                    ["ja", "パブリックビューイング会場"],
-                    ["en", "Venue Music Bar ROCKAHOLIC Shimokitazawa"]
-                ]),
-                url: TranslatableValues.createUnifiedStatement("https://tiget.net/events/284427"),
-            }),
-            new LinkMaster({
-                name: TranslatableValues.create([
-                    ["ja", "配信"],
-                    ["en", "Live Streaming"],
-                ]),
-                url: TranslatableValues.createUnifiedStatement("https://www.youtube.com/live/yBPC12XM3gg")
-            })
-        ]
-    }),
-    new NewsMaster({
-        text: TranslatableValues.create([
             ["ja", "2024-02-04 V³アワード 出演"],
             ["en", "2024-02-04 V³ AWARD"]
         ]),
@@ -59,10 +37,7 @@ const newsMasterData: NewsMaster[] = [
         ]
     }),
     new NewsMaster({
-        text: TranslatableValues.create([
-            ["ja", "2023-12-29 Vack-ON!! vol.2 出演"],
-            ["en", "2023-12-29 Vack-ON!! vol.2"]
-        ]),
+        text: TranslatableValues.createUnifiedStatement("2023-12-29 Vack-ON!! vol.2"),
         links: [
             new LinkMaster({
                 name: TranslatableValues.create([
@@ -70,7 +45,14 @@ const newsMasterData: NewsMaster[] = [
                     ["en", "Venue Takara Osaka"]
                 ]),
                 url: TranslatableValues.createUnifiedStatement("https://takara-live.com/osaka/"),
-            })
+            }),
+            new LinkMaster({
+                name: TranslatableValues.create([
+                    ["ja", "配信 (アーカイブは2023-12-31まで)"],
+                    ["en", "Streaming (The archive will be available until 2023-12-31"]
+                ]),
+                url: TranslatableValues.createUnifiedStatement("https://zaiko.io/event/360813"),
+            }),
         ]
     })
 ];


### PR DESCRIPTION
Close #236 

- New 
    - VIRTUALHOLIC歌枠リレーを下げ
    - Vack-ON を更新して、ZAIKOの配信チケットのリンクを追加
- Biography
    - Vack-ON を追加