### PR TITLE
DiscographyでEPやAlbumのトラックリストを表示

### DIFF
--- a/.storybook/stories/components/discography/ProductCard.stories.tsx
+++ b/.storybook/stories/components/discography/ProductCard.stories.tsx
@@ -18,6 +18,14 @@ productCard.args = {
         genre: "Alternative",
         dateOfRelease: "2022-04-24",
         description: "1st EP M3-2022春 お-07a頒布で頒布・Boothにて販売",
+        tracks: [
+            "Introduction",
+            "sparkler",
+            "monologue",
+            "CUTE AGGRESSION!!!!",
+            "Irony",
+            "Enchanted",
+        ],
         credits: [
             "作曲・Tr2作詞 マッチ",
             "Tr5作詞 esora uma [浮遊信号]",

--- a/src/components/biography/TrackList.tsx
+++ b/src/components/biography/TrackList.tsx
@@ -1,0 +1,24 @@
+import React, { useState } from "react";
+
+type Props = {
+    tracks: string[];
+};
+
+const TrackList: React.FC<Props> = ({tracks}: Props) => {
+    const [visible, setVisible] = useState<boolean>(false);
+    const listVisibilityClassName = visible ? "visible" : "hidden";
+    const buttonText = visible ? "Close track list -" : "Open track list +";
+    const onButtonClick = () => {setVisible(!visible)};
+    return <>
+        <button onClick={onButtonClick} className="text-gray">{buttonText}</button>
+        <ol className={`${listVisibilityClassName}`}>
+            {
+                tracks.map((track, index) => {
+                    return <li className={`text-sm`} key={index}>{`Tr${index+1} ${track}`}</li>}
+                )
+            }
+        </ol>
+    </>;
+};
+
+export default TrackList;

--- a/src/components/discography/ProductCard.tsx
+++ b/src/components/discography/ProductCard.tsx
@@ -4,6 +4,7 @@ import GenreLabel from "./GenreLabel";
 import BorderLinkButton from "./BorderLinkButton";
 import MvLinkButton from "./MvLinkButton";
 import { ProductSummary } from "../../services/discography/ProductService"; 
+import TrackList from "../biography/TrackList";
 
 type Props = {
     productSummary: ProductSummary;
@@ -17,14 +18,20 @@ const ProductCard: React.FC<Props> = ({productSummary}) => {
                 <DateOfRleaseLabel dateOfRelease={productSummary.dateOfRelease} />
                 <GenreLabel genre={productSummary.genre} />
             </div>
-            <div className="my-2">
-                { productSummary.credits.length > 0 && 
+            { productSummary.tracks.length > 0 &&
+                <div className="my-2">
+                    <TrackList tracks={productSummary.tracks} />
+                </div>
+            }
+            { productSummary.credits.length > 0 && 
+                <div className="my-2">
+                    <span className="text-center">Credits</span>
                     <ul>
                         {productSummary.credits.map((name, index) => <li className="text-sm" key={index}>{name}</li>)}
                     </ul>
-                }
-                <p className="w-full my-2">{productSummary.description}</p>
-            </div>
+                </div>
+            }
+            <p className="w-full my-2">{productSummary.description}</p>
             { productSummary.mvLinks.length > 0 && 
                 <div className="my-2 text-center">
                     <span className="p-2">Music video</span>

--- a/src/services/discography/InMemoryProductService.ts
+++ b/src/services/discography/InMemoryProductService.ts
@@ -11,6 +11,7 @@ export class ProductMaster {
     private genre: Genre;
     private dateOfRelease: Date;
     private description?: TranslatableValues;
+    private tracks: TranslatableValues[];
     private credits: TranslatableValues[];
     private mvLinks: LinkMaster[];
     private storeLinks: LinkMaster[];
@@ -22,6 +23,7 @@ export class ProductMaster {
         genre: Genre,
         dateOfRelease: Date,
         description?: TranslatableValues;
+        tracks?: TranslatableValues[],
         credits: TranslatableValues[],
         mvLinks: LinkMaster[],
         storeLinks: LinkMaster[],
@@ -33,6 +35,7 @@ export class ProductMaster {
         this.genre = props.genre;
         this.dateOfRelease = props.dateOfRelease;
         this.description = props.description;
+        this.tracks = props.tracks ? props.tracks : [];
         this.credits = props.credits;
         this.mvLinks = props.mvLinks;
         this.storeLinks = props.storeLinks;
@@ -46,6 +49,9 @@ export class ProductMaster {
             genre: this.genre,
             dateOfRelease: format(this.dateOfRelease, 'yyyy-MM-dd'),
             description: this.description?.getLocalizedValue(locale) || "",
+            tracks: this.tracks.map((trackMaster) => {
+                return trackMaster.getLocalizedValue(locale);
+            }),
             credits: this.credits.map((creditMaster) => {
                 return creditMaster.getLocalizedValue(locale);
             }),
@@ -107,7 +113,6 @@ const productMasterData: ProductMaster[] = [
         kind: "Single",
         genre: "Rock",
         dateOfRelease: new Date("2023-09-29"),
-        description: undefined,
         credits: [
             TranslatableValues.create([
                 ["ja", "Music 天野ドウジ [カクレゴ]"],
@@ -138,9 +143,23 @@ const productMasterData: ProductMaster[] = [
         genre: "Rock",
         dateOfRelease: new Date("2023-04-30"),
         description: TranslatableValues.create([
-            ["ja", "1st Album M3-2023春"],
-            ["en", "1st Album M3-2023-Spring"],
+            ["ja", "1st Album M3-2023春 (サブスク配信なし・CD販売のみ)"],
+            ["en", "1st Album M3-2023-Spring (Only CD sales)"],
         ]),
+        tracks: [
+            TranslatableValues.createUnifiedStatement("I breathe here.(instrumental)"),
+            TranslatableValues.createUnifiedStatement("Say,"),
+            TranslatableValues.createUnifiedStatement("Film"),
+            TranslatableValues.createUnifiedStatement("KANATA"),
+            TranslatableValues.createUnifiedStatement("MORE SO,KICK YOU CORE!!!!"),
+            TranslatableValues.createUnifiedStatement("Glimmer"),
+            TranslatableValues.createUnifiedStatement("Skymellia"),
+            TranslatableValues.createUnifiedStatement("Chilldish"),
+            TranslatableValues.createUnifiedStatement("(un)forgettable"),
+            TranslatableValues.createUnifiedStatement("Lonely Rainy"),
+            TranslatableValues.createUnifiedStatement("BLOOMING PAINTERS"),
+            TranslatableValues.createUnifiedStatement("Savior"),
+        ],
         credits: [
             TranslatableValues.create([
                 ["ja", "Tr1,2,5,6,10 Music / Tr6,10 Lyrics マッチ"],
@@ -271,9 +290,17 @@ const productMasterData: ProductMaster[] = [
         genre: "Alternative",
         dateOfRelease: new Date("2022-04-24"),
         description: TranslatableValues.create([
-            ["ja", "1st EP M3-2022春"],
-            ["en", "1st EP M3-2022-Spring"],
+            ["ja", "1st EP M3-2022春 (サブスク配信なし・CD販売のみ)"],
+            ["en", "1st EP M3-2022-Spring (Only CD sales)"],
         ]),
+        tracks: [
+            TranslatableValues.createUnifiedStatement("Introduction"),
+            TranslatableValues.createUnifiedStatement("sparkler"),
+            TranslatableValues.createUnifiedStatement("monologue"),
+            TranslatableValues.createUnifiedStatement("CUTE AGGRESSION!!!!"),
+            TranslatableValues.createUnifiedStatement("Irony"),
+            TranslatableValues.createUnifiedStatement("Enchanted"),
+        ],
         credits: [
             TranslatableValues.create([
                 ["ja", "Music/Tr2Lyrics マッチ"],

--- a/src/services/discography/ProductService.ts
+++ b/src/services/discography/ProductService.ts
@@ -14,6 +14,7 @@ export type ProductSummary = {
     genre: Genre;
     dateOfRelease: string; // yyyy-MM-dd;
     description: string;
+    tracks: string[];
     credits: string[];
     mvLinks: LinkItem[];
     storeLinks: LinkItem[];


### PR DESCRIPTION
refs #168

# 目論見

* Discographyのhtmlに曲名が載るのでGoogleで曲名を検索してこのページに着地する
* ページ内の説明でサブスクがなくCD販売のみの曲があることに気づける
* Albumの場合はトラックリストは長くなるので、クリックして展開

# 改修後のキャプチャ

初期状態

<img width="234" alt="image" src="https://github.com/01G271BR9H8WH1VNE8QHKYGDCX/yorudokimayu-info/assets/104892286/18752cb9-c662-4679-bd3a-dfa313fc2e0a">

展開状態

<img width="216" alt="image" src="https://github.com/01G271BR9H8WH1VNE8QHKYGDCX/yorudokimayu-info/assets/104892286/c79253a8-20c1-4db4-9ef7-359259d625ae">
