### PR TITLE
終了したイベントやコラボ歌唱情報などNewsからBiographyへ移動

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yorudokimayu-info",
-  "version": "1.3.38",
+  "version": "1.3.39",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/src/constants/externalLink.ts
+++ b/src/constants/externalLink.ts
@@ -11,7 +11,7 @@ const externalLink: ExternalLink = {
     booth: "https://461okmy.booth.pm/",
     youtube: "https://www.youtube.com/channel/UCOJS80LKLRTLihZioG5l73g",
     twitter: "https://twitter.com/461Okmy",
-    tiktok: "https://www.tiktok.com/@461okmy",
+    tiktok: "https://www.tiktok.com/@tiktokimayu",
 };
 
 export default externalLink;

--- a/src/services/biography/InMemoryBiographyService.ts
+++ b/src/services/biography/InMemoryBiographyService.ts
@@ -285,8 +285,8 @@ const collaborationMasterData: CollaborationMaster[] = [
             ["en", "PancakeCats Re:collection"]
         ]),
         partOfTheWork: TranslatableValues.create([
-            ["ja", "Tr.06 シゲキ的ドラスティックチューン(feat.拠鳥きまゆ) 歌唱"],
-            ["en", "Vocal Tr.06 Shigeki-like drastic tune (feat. Yorudo Kimayu)"],
+            ["ja", "Tr6 シゲキ的ドラスティックチューン(feat.拠鳥きまゆ) 歌唱"],
+            ["en", "Vocal Tr6 Shigeki-like drastic tune (feat. Yorudo Kimayu)"],
         ]),
         links: [
             new LinkMaster({
@@ -315,6 +315,30 @@ const collaborationMasterData: CollaborationMaster[] = [
         ]),
         links: [
             LinkMaster.createMusicVideoOnYouTube({id: 'L_QOpKQ5FeE'}),
+        ],
+    }),
+    new CollaborationMaster({
+        date: new Date('2025-04-27'),
+        productName: TranslatableValues.createUnifiedStatement('パンケーキキャッツ マッチ・アップ・マーチ！'),
+        partOfTheWork: TranslatableValues.create([
+            ["ja", 'Tr2 rolling, shoelace, 歌唱'],
+            ["en", 'Vocal Tr2 rolling, shoelace,'],
+        ]),
+        links: [
+            new LinkMaster({
+                name: TranslatableValues.create([
+                    ["ja", "特設サイト"],
+                    ["en", "Web site"],
+                ]),
+                url: TranslatableValues.createUnifiedStatement("https://pancakecats2025.studio.site/"),
+            }),
+            new LinkMaster({
+                name: TranslatableValues.create([
+                    ["ja", "クロスフェードデモ"],
+                    ["en", "Crossfade Demo"],
+                ]),
+                url: TranslatableValues.createUnifiedStatement("https://youtu.be/cgAylXphnls"),
+            }),
         ],
     }),
 ];
@@ -761,6 +785,26 @@ const eventHistoryMasterData: EventHistoryMaster[] = [
                 name: TranslatableValues.createUnifiedStatement('bitfan'),
             }),
         ],
+    }),
+    new EventHistoryMaster({
+        name: TranslatableValues.create([
+                ['ja', 'ぶいかふぇ♪ vol.112'],
+                ['en', 'Vcafe vol.112'],
+            ]),
+        date: new Date('2025-05-02'),
+        links: [
+            new LinkMaster({
+                url: TranslatableValues.createUnifiedStatement('https://jcm-event.bitfan.id/events/10721'),
+                name: TranslatableValues.createUnifiedStatement('bitfan'),
+            }),
+        ],
+    }),
+    new EventHistoryMaster({
+        name: TranslatableValues.create([
+            ['ja', '革命ロジック2025 Virtual Sounds Borderlessコラボステージ'],
+            ['en', 'Collaboration stage of "革命ロジック2025" and "Virtual Sounds Borderless"']
+        ]),
+        date: new Date('2025-05-04'),
     }),
 ];
 

--- a/src/services/home/InMemoryNewsService.ts
+++ b/src/services/home/InMemoryNewsService.ts
@@ -20,78 +20,18 @@ export class NewsMaster {
     }
 }
 
-const newsMasterData: NewsMaster[] = [
+const newsMasterData: NewsMaster[] = [    
     new NewsMaster({
         text: TranslatableValues.create([
-            ['ja', '2025-04-27 M3 2025 春 にて 2nd EP 「For,」をリリース'],
-            ['en', '2025-04-27 2nd EP "For," will be released at M3 2025 spring'],
-        ]),
-        links: [
-            new LinkMaster({
-                url: TranslatableValues.createUnifiedStatement('https://youtu.be/8NZKnncWR0s'),
-                name: TranslatableValues.create([
-                    ["ja", "クロスフェードデモ"],
-                    ["en", "Crossfade Demo"],
-                ]),
-            }),
-            new LinkMaster({
-                name: TranslatableValues.createUnifiedStatement('"For," music video'),
-                url: TranslatableValues.createUnifiedStatement('https://youtu.be/Fqy9kbq5-o4'),
-            }),
-            new LinkMaster({
-                name: TranslatableValues.createUnifiedStatement('"あるこ～る♡どりりあむ" music video'),
-                url: TranslatableValues.createUnifiedStatement("https://youtu.be/dflT1tpBExU")
-            }),
-        ],
-    }),
-    new NewsMaster({
-        text: TranslatableValues.create([
-            ['ja', '2025-04-27 M3 2025 春 パンケーキキャッツ Album マッチ・アップ・マーチ！ 1曲担当'],
-            ['en', '2025-04-27 Guest vocalist on PancakeCats Album "マッチ・アップ・マーチ！" will be released at M3 2025 Spring']
-        ]),
-        links: [
-            new LinkMaster({
-                name: TranslatableValues.create([
-                    ["ja", "特設サイト"],
-                    ["en", "Web site"],
-                ]),
-                url: TranslatableValues.createUnifiedStatement("https://pancakecats2025.studio.site/"),
-            }),
-            new LinkMaster({
-                name: TranslatableValues.create([
-                    ["ja", "クロスフェードデモ"],
-                    ["en", "Crossfade Demo"],
-                ]),
-                url: TranslatableValues.createUnifiedStatement("https://youtu.be/cgAylXphnls"),
-            }),
-        ],
-    }),
-    new NewsMaster({
-        text: TranslatableValues.create([
-            ['ja', '2025-05-02 ぶいかふぇ♪ vol.112'],
+            ['ja', '2025-05-02 ぶいかふぇ♪ vol.112 '],
             ['en', '2025-05-02 Vcafe vol.112'],
         ]),
         links: [
             new LinkMaster({
                 url: TranslatableValues.createUnifiedStatement('https://jcm-event.bitfan.id/events/10721'),
                 name: TranslatableValues.create([
-                    ['ja', '現地 (秋葉原トークライブBAR from scratch) / 配信 (bitfan) チケット'],
-                    ['en', 'Venue (Akihabara from scracth) / Streaming (bitfan) ticket'],
-                ]),
-            }),
-        ],
-    }),
-    new NewsMaster({
-        text: TranslatableValues.create([
-            ['ja', '2025-05-04 革命ロジック2025 Virtual Sounds Borderlessコラボステージ'],
-            ['en', '2025-05-04 Collaboration stage of "革命ロジック2025" and "Virtual Sounds Borderless"']
-        ]),
-        links: [
-            new LinkMaster({
-                url: TranslatableValues.createUnifiedStatement('https://t.livepocket.jp/e/kakumei2025'),
-                name: TranslatableValues.create([
-                    ['ja', '現地 (下北沢8会場) チケット'],
-                    ['en', 'Venue (8 live music club in Shimokitazawa) ticket']
+                    ['ja', '配信 (bitfan) チケット アーカイブは2025-05-08 23:59まで'],
+                    ['en', 'Streaming (bitfan) ticket will be available until 2025-05-08 23:59 (JST)'],
                 ]),
             }),
         ],


### PR DESCRIPTION
Close #347


主たる変更

* 終了したイベントについてはBiographyのイベント出演歴へ移動
* M3のゲストボーカル情報はBiographyのコラボ欄へ移動

ついでにやったこと

* ゲストボーカルのTr.0{n} を Tr{n}に揃える
* Biographyのtiktokのリンク切れ修正
    * アカウントが作り直されていた
